### PR TITLE
(instrument)(carts) create a degraded version of cart service

### DIFF
--- a/src/cartservice/src/services/CartService.cs
+++ b/src/cartservice/src/services/CartService.cs
@@ -33,17 +33,23 @@ namespace cartservice.services
 
         public async override Task<Empty> AddItem(AddItemRequest request, ServerCallContext context)
         {
+            // delay processing of add-to-cart requests for 1s 
+            System.Threading.Thread.Sleep(1000);
             await _cartStore.AddItemAsync(request.UserId, request.Item.ProductId, request.Item.Quantity);
             return Empty;
         }
 
         public override Task<Cart> GetCart(GetCartRequest request, ServerCallContext context)
         {
+            // delay processing of view cart requests for 1s
+            System.Threading.Thread.Sleep(1000);
             return _cartStore.GetCartAsync(request.UserId);
         }
 
         public async override Task<Empty> EmptyCart(EmptyCartRequest request, ServerCallContext context)
         {
+            // delay processing of empty-cart requests for 1s
+            System.Threading.Thread.Sleep(1000);
             await _cartStore.EmptyCartAsync(request.UserId);
             return Empty;
         }


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@harness.io>

### Background 
<!-- What was happening before this PR, and the problem(s) it solves -->

The loadgenerator performs multiple requests against the cart service - such as [adding to cart,](https://github.com/chaosnative/online-boutique-app/blob/9eeba27561cf96b44081ce777c90c52abf1211e1/src/loadgenerator/locustfile.py#L45) & [viewing it ](https://github.com/chaosnative/online-boutique-app/blob/9eeba27561cf96b44081ce777c90c52abf1211e1/src/loadgenerator/locustfile.py#L42). 

We want to simulate a degradation in the metrics returned by the loadgen and the frontend service due to a non-performant/erroneous carts. 

Hence, a sleep of 1000ms has been added to the the individual cart functions. 

The image generated from this instrumented carts will be used to demonstrate the efficacy of chaos tests on boutique and subsequent rollback triggered by it.  



### Fixes 
<!-- Link the issue(s) this PR fixes-->
### Change Summary
<!-- Short summary of the changes submitted -->

### Additional Notes
<!-- Any remaining concerns -->

### Testing Procedure
<!-- If applicable, write how to test for reviewers-->

### Related PRs or Issues 
<!-- Dependent PRs, or any relevant linked issues -->
